### PR TITLE
fixes issue with multiple filtered paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ function createPouchMiddleware(_paths) {
       if (path.changeFilter) {
         filteredAllDocs = allDocs.filter(path.changeFilter);
       }
-      allDocs.forEach(function (doc) {
+      filteredAllDocs.forEach(function (doc) {
         path.docs[doc._id] = doc;
       });
       path.propagateBatchInsert(filteredAllDocs, dispatch);

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ function createPouchMiddleware(_paths) {
       if (path.changeFilter) {
         filteredAllDocs = allDocs.filter(path.changeFilter);
       }
-      allDocs.forEach((doc) => {
+      filteredAllDocs.forEach((doc) => {
         path.docs[doc._id] = doc;
       });
       path.propagateBatchInsert(filteredAllDocs, dispatch);


### PR DESCRIPTION
Repro:

Create a middleware with 2 paths, each with filters:

State:
```

{ 
  todos: [],
  foobar: []
}
```

* Insert rows into each.  
* Reload redux state from pouchdb (refresh the page)
* State from 2nd path will be deleted immediately

I believe is a typo, related to the 1.0.0 batch insert PR from @mitchellhamilton

I apologize for not creating new tests for this, it was kind of complex and I didn't have enough time.  :/ ...