### PR TITLE
Call initialBatchDispatched with an error if allDocs throws an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ which is useful when metadata is needed or errors need custom handling.
 Arguments are `error, data, callback`. `callback` must be invoked with a potential error
 after custom handling is done.
 * `initialBatchDispatched` a function that is invoked once the initial set of
-data has been read from pouchdb and dispatched to the redux store.
+data has been read from pouchdb and dispatched to the redux store or if the data fails to be read from pouchdb it is called with an error.
 This comes handy if you want skip the initial updates to a store
 subscriber by delaying the subscription to the redux store
 until the initial state is present. For example, when your application is first

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,6 +71,8 @@ function createPouchMiddleware(_paths) {
       changes.on('change', function (change) {
         onDbChange(path, change, dispatch);
       });
+    }).catch(function (err) {
+      return initialBatchDispatched(err);
     });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,7 @@ function createPouchMiddleware(_paths) {
       changes.on('change', change => {
         onDbChange(path, change, dispatch);
       });
-    });
+    }).catch((err) => initialBatchDispatched(err));
   }
 
   function processNewStateForPath(path, state) {


### PR DESCRIPTION
This calls `initialBatchDispatched` if `db.allDocs` throws an error so the user can handle it. I also added a test for it and updated the README.

Closes #43